### PR TITLE
Added two new colours active icon and inactive icon

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,7 +4,7 @@ import { NavigationContainer, TabActions } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Ionicons, MaterialIcons, MaterialCommunityIcons, AntDesign } from '@expo/vector-icons';
 import {HomeStackScreen, ProfileStackScreen, MessageStackScreen, PostStackScreen, NotificationStackScreen} from './stack/Stack'
-import {PRIMARY_COLOR, LIGHT_GREY} from './constants/colors'
+import {PRIMARY_COLOR, LIGHT_GREY, ICON_ACTIVE_COLOR, ICON_INACTIVE_COLOR} from './constants/colors'
 
 import {decode, encode} from 'base-64'
 
@@ -28,8 +28,8 @@ export default function App() {
 <NavigationContainer>
 <Tab.Navigator  
         tabBarOptions={{
-          activeTintColor: PRIMARY_COLOR,
-          inactiveTintColor: LIGHT_GREY,
+          activeTintColor: ICON_ACTIVE_COLOR,
+          inactiveTintColor: ICON_INACTIVE_COLOR,
           showLabel: false,
           style: {
             borderTopColor:  PRIMARY_COLOR,

--- a/constants/colors.js
+++ b/constants/colors.js
@@ -1,2 +1,4 @@
 export const  PRIMARY_COLOR = '#66BEFD';
 export const  LIGHT_GREY = '#CFCFCF';
+export const  ICON_ACTIVE_COLOR = '#66BEFD';
+export const  ICON_INACTIVE_COLOR = '#CFCFCF'


### PR DESCRIPTION
# What does this PR do?
Pranjal and I  went over a demo, where we added an active icon colour and an inactive icon colour.


#Proof that this is working?
<img width="376" alt="Screen Shot 2020-06-20 at 11 35 36 AM" src="https://user-images.githubusercontent.com/32420740/85208001-35078c80-b2ea-11ea-91df-fee81b1cd55a.png">
